### PR TITLE
included pair files setting.

### DIFF
--- a/flask_static_digest/cli.py
+++ b/flask_static_digest/cli.py
@@ -20,7 +20,8 @@ def compile():
     _compile(current_app.static_folder,
              current_app.static_folder,
              current_app.config.get("FLASK_STATIC_DIGEST_BLACKLIST_FILTER"),
-             current_app.config.get("FLASK_STATIC_DIGEST_GZIP_FILES"))
+             current_app.config.get("FLASK_STATIC_DIGEST_GZIP_FILES"),
+             current_app.config.get("FLASK_STATIC_DIGEST_PAIRS"))
 
 
 @digest.command()

--- a/tests/example_app/config/settings.py
+++ b/tests/example_app/config/settings.py
@@ -1,1 +1,2 @@
 FLASK_STATIC_DIGEST_BLACKLIST_FILTER = [".txt"]
+FLASK_STATIC_DIGEST_PAIRS = [['foo.js','bar.html']]

--- a/tests/example_app/example/static/js/bar.html
+++ b/tests/example_app/example/static/js/bar.html
@@ -1,0 +1,1 @@
+<h1>HTML Page for foo controller</h1>

--- a/tests/example_app/example/static/js/foo.js
+++ b/tests/example_app/example/static/js/foo.js
@@ -1,0 +1,7 @@
+angular.module('app').component('foo', {
+    templateUrl: 'static/js/bar.html',
+    controllerAs: 'vm',
+       controller: ['', function(){
+        var vm = this;
+    }]
+});


### PR DESCRIPTION
If you have files that reference eachother, when you run digest compile the paths in the file being referenced do not automatically change. I included a setting here where you can include file pairs that reference each other, to search for the path and replace it with the correct md5'd file name. 