### PR TITLE
Added brotli support and improved gzip speed x2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       - name: "Install dependencies"
         run: |
           pip3 install flake8 black Flask==2.2.3
-          pip3 install -e .
+          pip3 install -e .[brotli]
       - name: "Lint code base"
         run: |
           flake8 .
           black --check .
-      - name: "Run test suite"
+      - name: "Run test suite for gzip and brotli"
         run: |
           cd tests/example_app
           export FLASK_APP=example.app
@@ -51,21 +51,29 @@ jobs:
           || (echo "File count before compiling test (team): fail" && exit 1)
           flask digest compile \
           && ls -laR example/static/ | wc -l \
-          | grep -q "36" \
+          | grep -q "42" \
           && (echo "File count after compiling test (index): pass" && exit 0) \
           || (echo "File count after compiling test (index): fail" && exit 1)
           ls -laR example/about/static/ | wc -l \
-          | grep -q "9" \
+          | grep -q "11" \
           && (echo "File count after compiling test (about): pass" && exit 0) \
           || (echo "File count after compiling test (about): fail" && exit 1)
           ls -laR example/contact/static/ | wc -l \
-          | grep -q "9" \
+          | grep -q "11" \
           && (echo "File count after compiling test (contact): pass" && exit 0) \
           || (echo "File count after compiling test (contact): fail" && exit 1)
           ls -laR example/about/team/static/ | wc -l \
-          | grep -q "9" \
+          | grep -q "11" \
           && (echo "File count after compiling test (team): pass" && exit 0) \
           || (echo "File count after compiling test (team): fail" && exit 1)
+          find . -type f | grep ".gz$" | wc -l \
+          | grep -q "14" \
+          && (echo "Check for gzip asset creation: pass" && exit 0) \
+          || (echo "Check for gzip asset creation: pass: fail" && exit 1)
+          find . -type f | grep ".br$" | wc -l \
+          | grep -q "14" \
+          && (echo "Check for brotli asset creation: pass" && exit 0) \
+          || (echo "Check for brotli asset creation: pass: fail" && exit 1)
           grep -q "js/modules/hello.js" example/static/cache_manifest.json \
           && (echo "Cache manifest has nested file test: pass" && exit 0) \
           || (echo "Cache manifest has nested file test: fail" && exit 1)
@@ -93,6 +101,7 @@ jobs:
           | grep -q 'https://cdn.example.com/about/static/team/app-023f768653c556fc2fcaf338b408c464.css' \
           && (echo 'Stylesheet is md5 tagged test (team): pass' && exit 0) \
           || (echo 'Stylesheet is md5 tagged test (team): fail' && exit 1)
+          kill $!
           flask digest clean \
           && ls -laR example/static/ | wc -l \
           | grep -q "26" \
@@ -110,9 +119,11 @@ jobs:
           | grep -q "5" \
           && (echo "File count after cleaning test (team): pass" && exit 0) \
           || (echo "File count after cleaning test (team): fail" && exit 1)
-          flask run -p 5001 &
+          flask run &
           sleep 5 \
-          && curl http://localhost:5001 \
+          && curl http://localhost:5000 \
           | grep -q 'https://cdn.example.com/static/js/app.js' \
           && (echo 'Javascript is not md5 tagged test: pass' && exit 0) \
           || (echo 'Javascript is not md5 tagged test: fail' && exit 1)
+          flask digest clean
+          kill $!

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ coverage.xml
 *.pot
 
 # End of https://www.gitignore.io/api/python,osx
+
+# Exclude local .venv
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-- Nothing yet!
+- Brotli support added by [Dr. Matthew Swabey](https://github.com/mattaw)
+- Remove `FLASK_STATIC_DIGEST_GZIP_FILES` gzip config option
+- Add `FLASK_STATIC_DIGEST_COMPRESSION` (defaults to ["gzip"] and replaces the old gzip config option)
 
 ## [0.3.0] - 2022-03-16
 
@@ -65,4 +67,3 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 [0.1.2]: https://github.com/nickjj/flask-static-digest/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/nickjj/flask-static-digest/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/nickjj/flask-static-digest/releases/tag/v0.1.0
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2019 Nick Janetakis
+Copyright (c) 2023 Matthew Swabey
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # What is Flask-Static-Digest? ![CI](https://github.com/nickjj/flask-static-digest/workflows/CI/badge.svg?branch=master)
 
 It is a Flask extension that will help make your static files production ready
-with very minimal effort on your part. It does this by md5 tagging and gzipping
-your static files after running a `flask digest compile` command that this
-extension adds to your Flask app.
+with very minimal effort on your part. It does this by creating md5 tagged
+versions and gzip and / or brotli compressed versions of your static files by
+running a `flask digest compile` command that this extension adds to your Flask
+app.
 
 It should be the last thing you do to your static files before uploading them
 to your server or CDN. Speaking of which, if you're using a CDN this extension
@@ -36,7 +37,8 @@ There's 3 pieces to this extension:
 
 1. It adds a custom Flask CLI command to your project. When you run this
    command it looks at your static files and then generates an md5 tagged
-   version of each file along with optionally gzipping them too.
+   version of each file along with optionally compressing them with gzip
+   and / or brotli.
 
 2. When the above command finishes it creates a `cache_manifest.json` file in
    your static folder which maps the regular file names, such as
@@ -62,6 +64,8 @@ Video](https://img.youtube.com/vi/-Xd84hlIjkI/0.jpg)](https://www.youtube.com/wa
 
 - `FLASK_STATIC_DIGEST_HOST_URL` has been added to configure an optional external host, aka. CDN ([explained here](#configuring-this-extension))
 - If your blueprints have static files they will get digested now too (including nested blueprints!)
+- Optional Brotli support has been added
+- `FLASK_STATIC_DIGEST_COMPRESSION` has been added to control compression ([explained here](#configuring-this-extension))
 
 ## Table of Contents
 
@@ -73,7 +77,7 @@ Video](https://img.youtube.com/vi/-Xd84hlIjkI/0.jpg)](https://www.youtube.com/wa
 - [Potentially updating your .gitignore file](#potentially-updating-your-gitignore-file)
 - [FAQ](#faq)
   - [What about development vs production and performance implications?](#what-about-development-vs-production-and-performance-implications)
-  - [Why bother gzipping your static files here instead of with nginx?](#why-bother-gzipping-your-static-files-here-instead-of-with-nginx)
+  - [Why bother compressing your static files here instead of with nginx?](#why-bother-compressing-your-static-files-here-instead-of-with-nginx)
   - [How do you use this extension with Webpack or another build tool?](#how-do-you-use-this-extension-with-webpack-or-another-build-tool)
   - [Migrating from Flask-Webpack](#migrating-from-flask-webpack)
   - [How do you use this extension with Docker?](#how-do-you-use-this-extension-with-docker)
@@ -83,9 +87,13 @@ Video](https://img.youtube.com/vi/-Xd84hlIjkI/0.jpg)](https://www.youtube.com/wa
 
 ## Installation
 
-*You'll need to be running Python 3.5+ and using Flask 1.0 or greater.*
+*You'll need to be running Python 3.6+ and using Flask 1.0 or greater.*
 
 `pip install Flask-Static-Digest`
+
+To install with Brotli support:
+
+`pip install Flask-Static-Digest[brotli]`
 
 ### Example directory structure for a 'hello' app
 
@@ -144,7 +152,7 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  digest  md5 tag and gzip static files.
+  digest  md5 tag and compress static files.
   routes  Show the routes for the app.
   run     Run a development server.
   shell   Run a shell in the app context.
@@ -160,7 +168,7 @@ Running `flask digest` will produce this help menu:
 ```sh
 Usage: flask digest [OPTIONS] COMMAND [ARGS]...
 
-  md5 tag and gzip static files.
+  md5 tag and compress static files.
 
 Options:
   --help  Show this message and exit.
@@ -179,8 +187,8 @@ the input and output path of where to look for and create the newly digested
 and compressed files.
 
 At a high level it recursively loops over all of the files it finds in that
-directory and then generates the md5 tagged and gzipped versions of each file.
-It also creates a `cache_manifest.json` file in the root of your
+directory and then generates the md5 tagged and compressed versions of each
+file. It also creates a `cache_manifest.json` file in the root of your
 `static_folder`.
 
 That manifest file is machine generated meaning you should not edit it unless
@@ -220,37 +228,43 @@ the file are.*
 Inspects your Flask app's and blueprint's `static_folder` and uses that as the
 input path of where to look for digested and compressed files.
 
-It will recursively delete files that have a file extension of `.gz` and also
-deletes files that have been digested. It determines if a file has been
-digested based on its file name. In other words, it will delete files that
-match this regexp `r"-[a-f\d]{32}"`.
+It will recursively delete files that have a file extension of `.gz` or `.br`
+and files that have been digested. It determines if a file has been digested
+based on its file name. In other words, it will delete files that match this
+regexp `r"-[a-f\d]{32}"`.
 
-In the end that means if you had these 4 files in your static folder:
+In the end that means if you had these 6 files in your static folder:
 
 - `images/flask.png`
 - `images/flask.png.gz`
+- `images/flask.png.br`
 - `images/flask-f86b271a51b3cfad5faa9299dacd987f.png`
 - `images/flask-f86b271a51b3cfad5faa9299dacd987f.png.gz`
+- `images/flask-f86b271a51b3cfad5faa9299dacd987f.png.br`
 
-And you decided to run the clean command, the last 3 files would be deleted
+And you decided to run the clean command, the last 5 files would be deleted
 leaving you with the original `images/flask.png`.
 
 ## Configuring this extension
 
-By default this extension will md5 tag all files it finds in your configured
-`static_folder`. It will also create gzipped versions of each file and it won't
-prefix your static files with an external host.
+By default this extension will create md5 tagged versions of all files it finds
+in your configured `static_folder`. It will also create gzip'ed versions of each
+file and it won't prefix your static files with an external host.
 
-If you don't like any of this behavior, you can optionally configure:
+If you don't like any of this behavior or you wish to enable brotli you can
+optionally configure:
 
 ```py
 FLASK_STATIC_DIGEST_BLACKLIST_FILTER = []
 # If you want specific extensions to not get md5 tagged you can add them to
 # the list, such as: [".htm", ".html", ".txt"]. Make sure to include the ".".
 
-FLASK_STATIC_DIGEST_GZIP_FILES = True
-# When set to False then gzipped files will not be created but static files
-# will still get md5 tagged.
+FLASK_STATIC_DIGEST_COMPRESSION = ["gzip"]
+# Optionally compress your static files, supported values are:
+#   []                 avoids any compression
+#   ["gzip"]           uses gzip
+#   ["brotli"]         uses brotli (prefer either gzip or both)
+#   ["gzip", "brotli"] uses both
 
 FLASK_STATIC_DIGEST_HOST_URL = None
 # When set to a value such as https://cdn.example.com and you use static_url_for
@@ -328,7 +342,7 @@ it produces.
 But if you're not using Webpack or another asset build tool then the static
 files that are a part of your project might have the same source and
 destination directory. If that's the case, chances are you'll want to git
-ignore the md5 tagged files as well as the gzipped and `cache_manifest.json`
+ignore the md5 tagged files as well as the compressed and `cache_manifest.json`
 files from version control.
 
 For clarity, you want to ignore them because you'll be generating them on your
@@ -371,7 +385,7 @@ database query.
 performance of your web application. If anything it's going to speed it up and
 save you money on hosting**.
 
-That's because gzipped files can be upwards of 5-10x smaller so there's less
+That's because compressed files can be upwards of 5-10x smaller so there's less
 bytes to transfer over the network.
 
 Also with md5 tagging each file it means you can configure your web server such
@@ -392,15 +406,15 @@ static files using a CDN. Using this cache busting strategy makes configuring
 your CDN a piece of cake since you don't need to worry about ever expiring your
 cache manually.
 
-### Why bother gzipping your static files here instead of with nginx?
+### Why bother compressing your static files here instead of with nginx?
 
-You would still be using nginx's gzip features, but now instead of nginx having
-to gzip your files on the fly at run time you can configure nginx to use the
-pre-made gzipped files that this extension creates.
+You would still be using nginx's gzip / brotli features, but now instead of
+nginx having to compress your files on the fly at run time you can configure
+nginx to use the pre-made compressed files that this extension creates.
 
 This way you can benefit from having maximum compression without having nginx
-waste precious CPU cycles gzipping files on the fly. This gives you the best of
-both worlds -- the highest compression ratio with no noticeable run time
+waste precious CPU cycles compressing files on the fly. This gives you the best
+of both worlds -- the highest compression ratio with no noticeable run time
 performance penalty.
 
 ### How do you use this extension with Webpack or another build tool?
@@ -412,14 +426,15 @@ Typically the Webpack (or another build tool) work flow would look like this:
 
 - You configure Webpack with your source static files directory
 - You configure Webpack with your destination static files directory
-- Webpack processes your files in the source directory and copies them to the destination directory
+- Webpack processes your files in the source directory and copies them to the
+  destination directory
 - Flask is configured to serve static files from that destination directory
 
 For example, your source directory might be `assets/` inside of your project
 and the destination might be `myapp/static`.
 
 This extension will look at your Flask configuration for the `static_folder`
-and determine it's set to `myapp/static` so it will md5 tag and gzip those
+and determine it's set to `myapp/static` so it will md5 tag and compress those
 files. Your Webpack source files will not get digested and compressed.
 
 ### Migrating from Flask-Webpack
@@ -492,11 +507,11 @@ Let's say that besides having static files like your logo and CSS / JavaScript
 bundles you also have files uploaded by users. This could be things like a user
 avatar, blog post images or anything else.
 
-**You would still want to md5 tag and gzip these files but now we've run into a
-situation**. The `flask digest compile` command is meant to be run at deploy
-time and it could potentially be run from your dev box, inside of a Docker
-image, on a CI server or your production server. In these cases you wouldn't
-have access to the user uploaded files.
+**You would still want to md5 tag and compress these files but now we've run
+into a situation**. The `flask digest compile` command is meant to be run at
+deploy time and it could potentially be run from your dev box, inside of a
+Docker image, on a CI server or your production server. In these cases you
+wouldn't have access to the user uploaded files.
 
 But at the same time you have users uploading files at run time. They are
 changing all the time.
@@ -526,31 +541,31 @@ What's cool about this is you already did the database query to retrieve the
 record(s) from the database, so there's no extra database work to do. All you
 have to do is reference the file name field that's a part of your model.
 
-But that doesn't fully solve the problem. You'll still want to md5 tag and gzip
-your user uploaded content at run time and you would want to do this before you
-save the uploaded file into its final destination (local file system, S3,
-etc.).
+But that doesn't fully solve the problem. You'll still want to md5 tag and
+compress your user uploaded content at run time and you would want to do this
+before you save the uploaded file into its final destination (local file system,
+S3, etc.).
 
 This can be done completely separate from this extension and it's really going
-to vary depending on where you host your user uploaded content. For example
-some CDNs will automatically create gzipped files for you and they use things
-like an ETag header in the response to include a unique file name (and this is
-what you can store in your DB).
+to vary depending on where you host your user uploaded content. For example some
+CDNs will automatically create compressed files for you and they use things like
+an ETag header in the response to include a unique file name (and this is what
+you can store in your DB).
 
-So maybe md5 hashing and maybe gzipping your user uploaded content becomes an
+So maybe md5 hashing and maybe compressing your user uploaded content becomes an
 app specific responsibility, although I'm not opposed to maybe creating helper
 functions you can use but that would need to be thought out carefully.
 
 However the implementation is not bad. It's really only about 5 lines of code
 to do both things. Feel free to `CTRL + F` around the [code
 base](https://github.com/nickjj/flask-static-digest/blob/master/flask_static_digest/digester.py)
-for `hashlib` and `gzip` and you'll find the related code.
+for `hashlib`, `gzip` and `brotli` and you'll find the related code.
 
 **So with that said, here's a work flow you can do to deal with this today:**
 
 - User uploads file
 - Your Flask app potentially md5 tags / gzips the file if necessary
-- Your Flask app saves the file name + gzipped file to its final destination (local file system, S3, etc.)
+- Your Flask app saves the file name + compressed file to its final destination (local file system, S3, etc.)
 - Your Flask app saves the final unique file name to your database
 
 That final unique file name would be the md5 tagged version of the file that

--- a/flask_static_digest/__init__.py
+++ b/flask_static_digest/__init__.py
@@ -1,10 +1,10 @@
-import logging
 import json
+import logging
 import os
-
 from urllib.parse import urljoin
 
-from flask import request, url_for as flask_url_for
+from flask import request
+from flask import url_for as flask_url_for
 
 
 class FlaskStaticDigest(object):
@@ -22,8 +22,11 @@ class FlaskStaticDigest(object):
         :return: None
         """
         app.config.setdefault("FLASK_STATIC_DIGEST_BLACKLIST_FILTER", [])
-        app.config.setdefault("FLASK_STATIC_DIGEST_GZIP_FILES", True)
         app.config.setdefault("FLASK_STATIC_DIGEST_HOST_URL", None)
+        app.config.setdefault("FLASK_STATIC_DIGEST_COMPRESSION", ["gzip"])
+
+        compression = set(app.config["FLASK_STATIC_DIGEST_COMPRESSION"])
+        app.config["FLASK_STATIC_DIGEST_COMPRESSION"] = list(compression)
 
         self.host_url = app.config.get("FLASK_STATIC_DIGEST_HOST_URL")
 

--- a/flask_static_digest/cli.py
+++ b/flask_static_digest/cli.py
@@ -1,21 +1,52 @@
-import click
+import sys
 
+import click
 from flask import current_app
 from flask.cli import with_appcontext
 
-from flask_static_digest.digester import compile as _compile
 from flask_static_digest.digester import clean as _clean
+from flask_static_digest.digester import compile as _compile
 
 
 @click.group()
-def digest():
-    """md5 tag and gzip static files."""
-    pass
+@click.pass_context
+@with_appcontext
+def digest(ctx):
+    """md5 tag and compress static files."""
+
+    ctx.ensure_object(dict)
+
+    ctx.obj["gzip"] = False
+    ctx.obj["brotli"] = False
+    ctx.obj["blacklist_filter"] = current_app.config.get(
+        "FLASK_STATIC_DIGEST_BLACKLIST_FILTER"
+    )
+
+    compression = current_app.config.get("FLASK_STATIC_DIGEST_COMPRESSION")
+
+    for algo in compression:
+        if algo == "gzip":
+            ctx.obj["gzip"] = True
+        elif algo == "brotli":
+            try:
+                import brotli  # noqa: F401
+            except ModuleNotFoundError:
+                click.echo("Error: Python package 'brotli' not installed.")
+                sys.exit(78)  # sysexits.h 78 EX_CONFIG configuration error
+            else:
+                ctx.obj["brotli"] = True
+        else:
+            click.echo(
+                f"{algo} is not a supported compression value, it must be"
+                " 'gzip' or 'brotli'"
+            )
+            sys.exit(78)
 
 
 @digest.command()
+@click.pass_context
 @with_appcontext
-def compile():
+def compile(ctx):
     """Generate optimized static files and a cache manifest."""
     for blueprint in [current_app, *current_app.blueprints.values()]:
         if not blueprint.static_folder:
@@ -24,14 +55,16 @@ def compile():
         _compile(
             blueprint.static_folder,
             blueprint.static_folder,
-            current_app.config.get("FLASK_STATIC_DIGEST_BLACKLIST_FILTER"),
-            current_app.config.get("FLASK_STATIC_DIGEST_GZIP_FILES"),
+            ctx.obj["blacklist_filter"],
+            ctx.obj["gzip"],
+            ctx.obj["brotli"],
         )
 
 
 @digest.command()
+@click.pass_context
 @with_appcontext
-def clean():
+def clean(ctx):
     """Remove generated static files and cache manifest."""
     for blueprint in [current_app, *current_app.blueprints.values()]:
         if not blueprint.static_folder:
@@ -39,6 +72,7 @@ def clean():
 
         _clean(
             blueprint.static_folder,
-            current_app.config.get("FLASK_STATIC_DIGEST_BLACKLIST_FILTER"),
-            current_app.config.get("FLASK_STATIC_DIGEST_GZIP_FILES"),
+            ctx.obj["blacklist_filter"],
+            ctx.obj["gzip"],
+            ctx.obj["brotli"],
         )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="Flask-Static-Digest",
-    version="0.3.0",
+    version="0.4.0",
     author="Nick Janetakis",
     author_email="nick.janetakis@gmail.com",
     url="https://github.com/nickjj/flask-static-digest",
@@ -15,6 +15,7 @@ setup(
     python_requires=">=3.6",
     zip_safe=False,
     install_requires=["Flask>=1.0"],
+    extras_require={"brotli": ["Brotli>=1.0.9"]},
     entry_points={
         "flask.commands": ["digest=flask_static_digest.cli:digest"],
     },

--- a/tests/example_app/config/settings.py
+++ b/tests/example_app/config/settings.py
@@ -1,2 +1,3 @@
 FLASK_STATIC_DIGEST_BLACKLIST_FILTER = [".txt"]
 FLASK_STATIC_DIGEST_HOST_URL = "https://cdn.example.com"
+FLASK_STATIC_DIGEST_COMPRESSION = ["gzip", "brotli"]

--- a/tests/example_app/requirements.txt
+++ b/tests/example_app/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.2.3
-Flask-Static-Digest==0.3.0
+Flask-Static-Digest==0.4.0
+Brotli==1.0.9


### PR DESCRIPTION
Now requires Google Brotli.

Added new option to turn Brotli support on and off: FLASK_STATIC_DIGEST_BROTLI_FILES

Improved gzip performance x2 by copying already gzipped file vs. gzipping it twice.