### PR TITLE
Allow for host urls to include paths

### DIFF
--- a/flask_static_digest/__init__.py
+++ b/flask_static_digest/__init__.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from urllib.parse import urljoin
 
 from flask import request
 from flask import url_for as flask_url_for
@@ -55,10 +54,17 @@ class FlaskStaticDigest(object):
         except (FileNotFoundError, Exception):
             pass
 
-    def _prepend_host_url(self, host, filename):
-        return urljoin(
-            self.host_url, "/".join([self.static_url_path, filename])
-        )
+    def _custom_url_join(self, url_path):
+        """
+        Join the host URL with another URL path.
+        :param url_path: The URL returned by url_for
+        :type url_path: str
+        :return: Joined URL
+        """
+        if self.host_url is None:
+            return url_path
+
+        return "/".join([self.host_url.rstrip("/"), url_path.lstrip("/")])
 
     def static_url_for(self, endpoint, **values):
         """
@@ -83,4 +89,4 @@ class FlaskStaticDigest(object):
         filename = values.get("filename", None)
         values["filename"] = manifest.get(filename, filename)
 
-        return urljoin(self.host_url, flask_url_for(endpoint, **values))
+        return self._custom_url_join(flask_url_for(endpoint, **values))


### PR DESCRIPTION
The urllib.parse.urljoin function will discard the path of the url if the joined path is absolute (i.e. starts with a slash).
E.g.
```py
from urllib.parse import urljoin

host = "https://cdn.example.com/path/to/static/"
url = "/css/image.png"
print(urljoin(host, url))
# output: https://cdn.example.com/css/image.png
```

This poses a problem because flask.url_for will always return absolute paths and some cdn hosts like Google mandate a path to use their Cloud storage buckets as cdn. My solution suggests removing trailing and leading slashes from host and url respectively and then concatenating them with a slash.
Successfully tested with the following hosts: None, "", "https://cdn.example.com", "https://cdn.example.com/", "https://cdn.example.com/path", "https://cdn.example.com/path/", "https://cdn.example.com/path/to/static", "https://cdn.example.com/path/to/static/".